### PR TITLE
Mark selected topic item

### DIFF
--- a/scss/topic-list.scss
+++ b/scss/topic-list.scss
@@ -132,10 +132,18 @@ div.education {
 .topic-list {
   display: flex;
 
-  .topic-list-item.visited {
-    .link-top-line a.title,
-    .topic-excerpt {
-      color: var(--primary-medium);
+  .topic-list-item {
+    &.visited {
+      .link-top-line a.title,
+      .topic-excerpt {
+        color: var(--primary-medium);
+      }
+    }
+
+    &.selected {
+      .custom-topic-layout {
+        box-shadow: inset 3px 0 0 var(--danger);
+      }
     }
   }
 


### PR DESCRIPTION
Hey👋 I noticed, on a discourse instance that I frequent, that the redditish theme would not highlight/mark the selected topic when using keyboard navigation (specifically the `j` and `k` keys to move between topics). 

Unfortunately I have no instance to test this change with but from my reading, this should mimic the behavior and look of the default discourse theme in showing a red bar to the left of each post when it is selected:

<img width="805" alt="Discourse Classic Theme where the second post is selected via j/k keyboard nav" src="https://github.com/awesomerobot/discourse-redditish-theme/assets/1690502/e548b128-5731-479b-b7bc-081df0d99632">

Here's how it should look in redditish with this PR:

<img width="732" alt="Screenshot 2023-07-23 at 10 40 44" src="https://github.com/awesomerobot/discourse-redditish-theme/assets/1690502/d8858deb-b688-4f4f-8a72-e5b6d118aa51">

Again, this is untested but maybe you can make something of it because it would make keyboard navigation much more usable in this theme.

