### PR TITLE
FIX: pass topic in to `navigateToTopic`

### DIFF
--- a/javascripts/discourse/connectors/topic-list-item/item.gjs
+++ b/javascripts/discourse/connectors/topic-list-item/item.gjs
@@ -53,7 +53,7 @@ export default class Item extends Component {
     if (wantsNewWindow(event)) {
       window.open(topic.lastUnreadUrl, "_blank");
     } else {
-      navigateToTopic(topic.lastUnreadUrl);
+      navigateToTopic(topic, topic.lastUnreadUrl);
     }
   }
 


### PR DESCRIPTION
Looks like `navigateToTopic` needs the topic param too, otherwise it doesn't work 