### PR TITLE
DEV: Migrate to new tag route URL format

### DIFF
--- a/javascripts/discourse/components/custom-tag-banner.gjs
+++ b/javascripts/discourse/components/custom-tag-banner.gjs
@@ -10,7 +10,7 @@ export default class CustomTagBanner extends Component {
   }
 
   get tag() {
-    return this.router.currentRoute?.params?.tag_name;
+    return this.router.currentRoute?.attributes?.tag;
   }
 
   <template>
@@ -20,9 +20,9 @@ export default class CustomTagBanner extends Component {
           <div class="custom-tag-banner_meta">
             <div class="custom-tag-banner_meta-text">
               <h1>
-                <a href="/tag/{{this.tag}}">
+                <a href={{this.tag.url}}>
                   {{icon "tag"}}
-                  {{this.tag}}
+                  {{this.tag.name}}
                 </a>
               </h1>
             </div>

--- a/javascripts/discourse/components/sidebar-about-category.gjs
+++ b/javascripts/discourse/components/sidebar-about-category.gjs
@@ -9,6 +9,7 @@ import DButton from "discourse/components/d-button";
 import categoryLink from "discourse/helpers/category-link";
 import { bind } from "discourse/lib/decorators";
 import { NotificationLevels } from "discourse/lib/notification-levels";
+import { getCategoryAndTagUrl } from "discourse/lib/url";
 import Composer from "discourse/models/composer";
 import { i18n } from "discourse-i18n";
 import CategoryNotificationsButton from "select-kit/components/category-notifications-button";
@@ -26,12 +27,11 @@ export default class SidebarAboutCategory extends Component {
     return this.router.currentRoute?.attributes?.category;
   }
 
-  // TODO(https://github.com/discourse/discourse/pull/36678): The string check can be
-  // removed using .discourse-compatibility once the PR is merged.
-  get normalizedTopTags() {
-    return (this.site.category_top_tags || []).map((t) =>
-      typeof t === "string" ? t : t.name
-    );
+  get topTags() {
+    return this.site.categoryTopTags.map((tag) => ({
+      name: tag.name,
+      href: getCategoryAndTagUrl(this.category, true, tag),
+    }));
   }
 
   get showTopicsForSubCategory() {
@@ -118,7 +118,7 @@ export default class SidebarAboutCategory extends Component {
           {{/if}}
 
         </div>
-        {{#if (or this.category.subcategories this.normalizedTopTags.length)}}
+        {{#if (or this.category.subcategories this.topTags.length)}}
 
           <div
             class="custom-right-sidebar_category-about -tags-and-subcategories"
@@ -133,17 +133,17 @@ export default class SidebarAboutCategory extends Component {
               </div>
             {{/if}}
 
-            {{#if this.normalizedTopTags.length}}
+            {{#if this.topTags.length}}
               <div class="custom-right-sidebar_tags">
                 <h4>{{i18n (themePrefix "top_tags")}}</h4>
                 <div class="discourse-tags">
-                  {{#each this.normalizedTopTags as |tag|}}
+                  {{#each this.topTags as |tag|}}
                     <a
-                      href="/tags/c/{{this.category.slug}}/{{tag}}"
-                      data-tag-name={{tag}}
+                      href={{tag.href}}
+                      data-tag-name={{tag.name}}
                       class="discourse-tag simple"
                     >
-                      {{tag}}
+                      {{tag.name}}
                     </a>
                   {{/each}}
                 </div>

--- a/javascripts/discourse/components/sidebar-about-tag.gjs
+++ b/javascripts/discourse/components/sidebar-about-tag.gjs
@@ -26,8 +26,8 @@ export default class SidebarAboutTag extends Component {
     return this.tag && !this.category;
   }
 
-  get tagName() {
-    return this.router.currentRoute.params?.tag_name;
+  get routeTag() {
+    return this.router.currentRoute?.attributes?.tag;
   }
 
   get category() {
@@ -42,9 +42,8 @@ export default class SidebarAboutTag extends Component {
 
   @action
   async getTagInfo() {
-    const tag = this.tagName;
-    if (tag) {
-      const result = await this.store.find("tag-info", tag);
+    if (this.routeTag) {
+      const result = await this.store.find("tag-info", this.routeTag.id);
       this.tag = result;
     } else {
       this.tag = null;
@@ -61,7 +60,7 @@ export default class SidebarAboutTag extends Component {
   async getTagNotificationLevel() {
     this.tagNotification = await this.store.find(
       "tagNotification",
-      this.tagName.toLowerCase()
+      this.routeTag.id
     );
   }
 
@@ -95,12 +94,12 @@ export default class SidebarAboutTag extends Component {
   }
 
   <template>
-    {{#if this.tagName}}
+    {{#if this.routeTag}}
       <div
         {{didInsert this.getTagInfo}}
-        {{didUpdate this.getTagInfo this.tagName}}
+        {{didUpdate this.getTagInfo this.routeTag}}
         {{didInsert this.getTagNotificationLevel}}
-        {{didUpdate this.getTagNotificationLevel this.tagName}}
+        {{didUpdate this.getTagNotificationLevel this.routeTag}}
       >
         {{#if this.shouldShow}}
           {{#if (or this.tag.description this.currentUser)}}

--- a/spec/system/category_top_tags_spec.rb
+++ b/spec/system/category_top_tags_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe "Category top tags in sidebar", system: true do
   it "displays category top tags with correct links" do
     visit("/c/#{category.slug}/#{category.id}")
 
-    expect(sidebar_tags).to have_tag_link(tag_name: tag1.name, category_slug: category.slug)
-    expect(sidebar_tags).to have_tag_link(tag_name: tag2.name, category_slug: category.slug)
+    expect(sidebar_tags).to have_tag_link(tag: tag1, category: category)
+    expect(sidebar_tags).to have_tag_link(tag: tag2, category: category)
   end
 
   it "does not display tags section when category has no top tags" do

--- a/spec/system/page_objects/components/sidebar_tags.rb
+++ b/spec/system/page_objects/components/sidebar_tags.rb
@@ -5,10 +5,10 @@ module PageObjects
     class SidebarTags < PageObjects::Components::Base
       SELECTOR = ".custom-right-sidebar_tags"
 
-      def has_tag_link?(tag_name:, category_slug:)
+      def has_tag_link?(tag:, category:)
         has_css?(
-          "#{SELECTOR} .discourse-tag[data-tag-name='#{tag_name}'][href*='/tags/c/#{category_slug}/#{tag_name}']",
-          text: tag_name,
+          "#{SELECTOR} .discourse-tag[data-tag-name='#{tag.name}'][href='/tags/c/#{category.slug}/#{category.id}/#{tag.slug}/#{tag.id}']",
+          text: tag.name,
         )
       end
 

--- a/spec/system/page_objects/components/tag_banner.rb
+++ b/spec/system/page_objects/components/tag_banner.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Components
+    class TagBanner < PageObjects::Components::Base
+      SELECTOR = ".custom-tag-banner"
+
+      def has_tag_link?(tag)
+        has_css?("#{SELECTOR} h1 a[href='#{tag.url}']", text: tag.name)
+      end
+    end
+  end
+end

--- a/spec/system/tag_url_format_spec.rb
+++ b/spec/system/tag_url_format_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require_relative "page_objects/components/tag_banner"
+require_relative "page_objects/components/sidebar_tags"
+
+RSpec.describe "Tag URL format", system: true do
+  let!(:theme) { upload_theme }
+
+  fab!(:user)
+  fab!(:tag) { Fabricate(:tag, name: "important") }
+  fab!(:category)
+  fab!(:category_topic) { Fabricate(:topic, category: category, tags: [tag]) }
+
+  let(:tag_banner) { PageObjects::Components::TagBanner.new }
+  let(:sidebar_tags) { PageObjects::Components::SidebarTags.new }
+
+  before do
+    SiteSetting.tagging_enabled = true
+    sign_in(user)
+  end
+
+  it "displays tag banner with correct link format" do
+    visit("/tag/#{tag.name}")
+
+    expect(tag_banner).to have_tag_link(tag)
+  end
+
+  it "displays category top tags with correct link format" do
+    visit("/c/#{category.slug}/#{category.id}")
+
+    expect(sidebar_tags).to have_tag_link(tag: tag, category: category)
+  end
+end

--- a/test/acceptance/redditish-tag-test.js
+++ b/test/acceptance/redditish-tag-test.js
@@ -13,17 +13,12 @@ acceptance("Redditish Theme | tag routes", function (needs) {
   });
 
   needs.pretender((server, helper) => {
-    server.get("/tag/important/l/latest.json", () => {
-      return helper.response(
-        cloneJSON(discoveryFixture["/tag/important/l/latest.json"])
-      );
-    });
-
-    server.get("/tag/:tag_name/info", () => {
+    server.get("/tag/1/info.json", () => {
       return helper.response({
         tag_info: {
           id: 1,
           name: "important",
+          slug: "important",
           description: "Important topics for discussion",
           topic_count: 5,
           pm_only: false,
@@ -33,10 +28,16 @@ acceptance("Redditish Theme | tag routes", function (needs) {
       });
     });
 
-    server.get("/tag/:tag_name/notifications", () => {
+    server.get("/tag/1/l/latest.json", () => {
+      return helper.response(
+        cloneJSON(discoveryFixture["/tag/important/l/latest.json"])
+      );
+    });
+
+    server.get("/tag/1/notifications.json", () => {
       return helper.response({
         tag_notification: {
-          id: "important",
+          id: 1,
           notification_level: 1,
         },
       });
@@ -44,7 +45,7 @@ acceptance("Redditish Theme | tag routes", function (needs) {
   });
 
   test("displays tag banner with tag name", async function (assert) {
-    await visit("/tag/important");
+    await visit("/tag/important/1");
 
     assert
       .dom(".custom-tag-banner h1")


### PR DESCRIPTION
What is the problem?

discourse/discourse@737577e8b47feda9535bd89963994851b491dc09 changes tag routes from `/tag/:name` to
`/tag/:slug/:id` format. The theme components were using the old
`tag_name` route parameter and constructing URLs manually with tag
names, which will break with the new routing.

What is the solution?

Update components to use the full tag object from route attributes
instead of just the tag name parameter:

- `CustomTagBanner`: Use `router.currentRoute.attributes.tag` and
  `tag.url` property for the link href
- `SidebarAboutTag`: Use route tag object with numeric `tag.id` for
  `tag-info` and `tagNotification` store lookups
- `SidebarAboutCategory`: Use `site.categoryTopTags` getter and
  `getCategoryAndTagUrl` helper for URL construction
