### PR TITLE
FIX: adjust body class to avoid partial matches

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -127,11 +127,11 @@ body {
 .btn-primary,
 .btn {
   &:not(
-      .btn-icon,
-      [class*="popup-menu-btn"],
-      [class*="post-action-menu__"],
-      [class*="topic-map__"]
-    ) {
+    .btn-icon,
+    [class*="popup-menu-btn"],
+    [class*="post-action-menu__"],
+    [class*="topic-map__"]
+  ) {
     padding: 0.5em 1em;
   }
 }

--- a/common/common.scss
+++ b/common/common.scss
@@ -60,7 +60,7 @@ body {
   /* pepesilva.jpg */
   &.tags-page,
   &[class*="navigation-"]:not([class*="archetype-"]),
-  &[class*="category-"]:not([class*="archetype-"]) {
+  &[class*="navigation-category"]:not([class*="archetype-"]) {
     #main-outlet-wrapper {
       grid-template-areas:
         "category-banner category-banner category-banner category-banner category-banner category-banner"
@@ -94,7 +94,7 @@ body {
 
   &.has-sidebar-page.tags-page,
   &.has-sidebar-page[class*="navigation-"]:not([class*="archetype-"]),
-  &.has-sidebar-page[class*="category-"]:not([class*="archetype-"]) {
+  &.has-sidebar-page[class*="navigation-category"]:not([class*="archetype-"]) {
     #main-outlet-wrapper {
       grid-template-areas:
         "sidebar category-banner category-banner category-banner category-banner category-banner"
@@ -127,11 +127,11 @@ body {
 .btn-primary,
 .btn {
   &:not(
-    .btn-icon,
-    [class*="popup-menu-btn"],
-    [class*="post-action-menu__"],
-    [class*="topic-map__"]
-  ) {
+      .btn-icon,
+      [class*="popup-menu-btn"],
+      [class*="post-action-menu__"],
+      [class*="topic-map__"]
+    ) {
     padding: 0.5em 1em;
   }
 }

--- a/common/common.scss
+++ b/common/common.scss
@@ -60,7 +60,7 @@ body {
   /* pepesilva.jpg */
   &.tags-page,
   &[class*="navigation-"]:not([class*="archetype-"]),
-  &[class*="navigation-category"]:not([class*="archetype-"]) {
+  &.navigation-category:not([class*="archetype-"]) {
     #main-outlet-wrapper {
       grid-template-areas:
         "category-banner category-banner category-banner category-banner category-banner category-banner"
@@ -94,7 +94,7 @@ body {
 
   &.has-sidebar-page.tags-page,
   &.has-sidebar-page[class*="navigation-"]:not([class*="archetype-"]),
-  &.has-sidebar-page[class*="navigation-category"]:not([class*="archetype-"]) {
+  &.has-sidebar-page.navigation-category:not([class*="archetype-"]) {
     #main-outlet-wrapper {
       grid-template-areas:
         "sidebar category-banner category-banner category-banner category-banner category-banner"

--- a/scss/right-sidebar.scss
+++ b/scss/right-sidebar.scss
@@ -4,7 +4,6 @@
   gap: 1em;
   margin-top: 1.5em;
   grid-area: sidebar2;
-  position: sticky;
   top: calc(var(--header-offset) + 1em);
   align-self: start;
 


### PR DESCRIPTION
Fixes a layout issue where the body class `uc-enable-simplified-category-creation` from the upcoming changes feature was triggering `[class*="category-"]` unintentionally. The `navigation-category` class accomplishes the same thing in a much more specific way. 

I've also removed a default `position: sticky;` style I added recently, having forgotten that this was better managed by a height media query.