### PR TITLE
UX: cache and improve the recent topics sidebar, add likes setting

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -211,3 +211,8 @@ html.composer-open #main-outlet {
 .welcome-banner__title {
   font-size: var(--font-up-4);
 }
+
+// calendar on topic lists
+.fc-view-harness {
+  background: var(--secondary);
+}

--- a/javascripts/discourse/api-initializers/track-recent-topics.js
+++ b/javascripts/discourse/api-initializers/track-recent-topics.js
@@ -1,0 +1,8 @@
+import { apiInitializer } from "discourse/lib/api";
+
+export default apiInitializer((api) => {
+  const recentTopics = api.container.lookup("service:recent-topics");
+  const appEvents = api.container.lookup("service:app-events");
+
+  appEvents.on("page:topic-loaded", recentTopics, "recordVisit");
+});

--- a/javascripts/discourse/components/sidebar-latest-topics.gjs
+++ b/javascripts/discourse/components/sidebar-latest-topics.gjs
@@ -1,5 +1,4 @@
 import Component from "@glimmer/component";
-import { tracked } from "@glimmer/tracking";
 import { get } from "@ember/helper";
 import { action } from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
@@ -11,109 +10,131 @@ import formatDate from "discourse/helpers/format-date";
 import topicLink from "discourse/helpers/topic-link";
 import { i18n } from "discourse-i18n";
 
-export default class LatestTopicsSidebar extends Component {
-  @service store;
-  @service currentUser;
+// one per topic we render, so the sidebar reserves its height while loading
+const PLACEHOLDERS = [1, 2, 3];
 
-  @tracked latestTopics = null;
+export default class LatestTopicsSidebar extends Component {
+  @service recentTopics;
+
+  get latestTopics() {
+    return this.recentTopics.topics;
+  }
+
+  get isLoading() {
+    return this.recentTopics.topics === null;
+  }
 
   @action
-  async getLatestTopics() {
-    let topicList;
-
-    if (this.currentUser) {
-      topicList = await this.store.findFiltered("topicList", {
-        filter: "read",
-        params: {
-          order: "latest",
-        },
-      });
-    } else {
-      topicList = await this.store.findFiltered("topicList", {
-        filter: "latest",
-        params: {
-          order: "created",
-        },
-      });
-    }
-
-    this.latestTopics = topicList.topics
-      .filter((topic) => !topic.closed)
-      .slice(0, 3);
+  getLatestTopics() {
+    this.recentTopics.load();
   }
 
   <template>
-    <h4>{{i18n (themePrefix "recent_topics")}}</h4>
+    {{! hidden entirely rather than left as an empty card }}
+    {{#unless this.recentTopics.isEmpty}}
+      <div class="custom-right-sidebar_recent">
+        {{#if this.recentTopics.usingFallback}}
+          <h4>{{i18n (themePrefix "hot_topics")}}</h4>
+        {{else}}
+          <h4>{{i18n (themePrefix "recent_topics")}}</h4>
+        {{/if}}
 
-    <div
-      class="custom-right-sidebar_recent-topics"
-      {{didInsert this.getLatestTopics}}
-    >
-      {{#each this.latestTopics as |topic|}}
-        {{! this is largely topic-list-item.hbr,
+        <div
+          class="custom-right-sidebar_recent-topics"
+          {{didInsert this.getLatestTopics}}
+        >
+          {{#if this.isLoading}}
+            {{#each PLACEHOLDERS}}
+              <div class="custom-right-sidebar_recent-topics-wrapper">
+                <div class="custom-right-sidebar_recent-topics-placeholder">
+                  <div
+                    class="placeholder-line --meta placeholder-animation"
+                  ></div>
+                  <div
+                    class="placeholder-line --title placeholder-animation"
+                  ></div>
+                  <div
+                    class="placeholder-line --title --short placeholder-animation"
+                  ></div>
+                  <div
+                    class="placeholder-line --meta placeholder-animation"
+                  ></div>
+                </div>
+              </div>
+            {{/each}}
+          {{/if}}
+
+          {{#each this.latestTopics as |topic|}}
+            {{! this is largely topic-list-item.hbr,
         but using that component directly was causing
         eyeline issues with loading more topics on }}
-        <div class="custom-right-sidebar_recent-topics-wrapper">
-          {{! template-lint-disable no-nested-interactive }}
-          <a
-            class="custom-topic-layout"
-            href="{{topic.url}}/{{topic.last_read_post_number}}"
-          >
-            <div class="custom-topic-layout_meta">
-              {{#unless this.hideCategory}}
-                {{#unless topic.isPinnedUncategorized}}
-                  {{categoryLink topic.category}}
-                  <span class="bullet-separator">&bull;</span>
-                {{/unless}}
-              {{/unless}}
+            <div class="custom-right-sidebar_recent-topics-wrapper">
+              {{! template-lint-disable no-nested-interactive }}
+              <a
+                class="custom-topic-layout"
+                href="{{topic.url}}/{{topic.last_read_post_number}}"
+              >
+                <div class="custom-topic-layout_meta">
+                  {{#unless this.hideCategory}}
+                    {{#unless topic.isPinnedUncategorized}}
+                      {{categoryLink topic.category}}
+                      <span class="bullet-separator">&bull;</span>
+                    {{/unless}}
+                  {{/unless}}
 
-              <span class="custom-topic-layout_meta-posted">
-                <span class="custom-topic-layout_meta-posted-by">Posted by</span>
-                <a
-                  data-user-card={{get topic.posters "0.user.username"}}
-                  href="/u/{{get topic.posters '0.user.username'}}"
-                >@{{get topic.posters "0.user.username"}}</a>
-                {{formatDate
-                  topic.createdAt
-                  format="medium"
-                  noTitle="true"
-                  leaveAgo="true"
-                }}
-              </span>
+                  <span class="custom-topic-layout_meta-posted">
+                    <span class="custom-topic-layout_meta-posted-by">Posted by</span>
+                    <a
+                      data-user-card={{get topic.posters "0.user.username"}}
+                      href="/u/{{get topic.posters '0.user.username'}}"
+                    >@{{get topic.posters "0.user.username"}}</a>
+                    {{formatDate
+                      topic.createdAt
+                      format="medium"
+                      noTitle="true"
+                      leaveAgo="true"
+                    }}
+                  </span>
+                </div>
+
+                <h2 class="link-top-line">
+                  {{~topicLink topic class="raw-link raw-topic-link"}}
+                </h2>
+
+                <div class="link-bottom-line">
+                  {{discourseTags
+                    topic
+                    mode="list"
+                    tagsForUser=this.tagsForUser
+                  }}
+                </div>
+
+                {{#if topic.thumbnails}}
+                  <div class="custom-topic-layout_image">
+                    <img
+                      height={{get topic.thumbnails "0.height"}}
+                      width={{get topic.thumbnails "0.width"}}
+                      src={{get topic.thumbnails "0.url"}}
+                    />
+                  </div>
+                {{/if}}
+
+                <div class="custom-topic-layout_bottom-bar">
+                  <span class="reply-count">
+                    {{icon "reply"}}
+                    {{topic.replyCount}}
+                    {{i18n "replies"}}
+                  </span>
+                  <span class="share-toggle">
+                    {{icon "link"}}
+                    {{i18n "post.quote_share"}}
+                  </span>
+                </div>
+              </a>
             </div>
-
-            <h2 class="link-top-line">
-              {{~topicLink topic class="raw-link raw-topic-link"}}
-            </h2>
-
-            <div class="link-bottom-line">
-              {{discourseTags topic mode="list" tagsForUser=this.tagsForUser}}
-            </div>
-
-            {{#if topic.thumbnails}}
-              <div class="custom-topic-layout_image">
-                <img
-                  height={{get topic.thumbnails "0.height"}}
-                  width={{get topic.thumbnails "0.width"}}
-                  src={{get topic.thumbnails "0.url"}}
-                />
-              </div>
-            {{/if}}
-
-            <div class="custom-topic-layout_bottom-bar">
-              <span class="reply-count">
-                {{icon "reply"}}
-                {{topic.replyCount}}
-                {{i18n "replies"}}
-              </span>
-              <span class="share-toggle">
-                {{icon "link"}}
-                {{i18n "post.quote_share"}}
-              </span>
-            </div>
-          </a>
+          {{/each}}
         </div>
-      {{/each}}
-    </div>
+      </div>
+    {{/unless}}
   </template>
 }

--- a/javascripts/discourse/components/sidebar-welcome.gjs
+++ b/javascripts/discourse/components/sidebar-welcome.gjs
@@ -49,9 +49,7 @@ export default class SidebarWelcome extends Component {
           />
         {{/if}}
       </div>
-      <div class="custom-right-sidebar_recent">
-        <SidebarLatestTopics />
-      </div>
+      <SidebarLatestTopics />
     {{/if}}
   </template>
 }

--- a/javascripts/discourse/connectors/topic-list-item/item.gjs
+++ b/javascripts/discourse/connectors/topic-list-item/item.gjs
@@ -155,6 +155,14 @@ export default class Item extends Component {
       {{/unless}}
 
       <div class="custom-topic-layout_bottom-bar">
+        {{#if settings.show_like_count}}
+          <span class="like-count">
+            {{icon "heart"}}
+            {{@outletArgs.topic.like_count}}
+            {{i18n "likes"}}
+          </span>
+        {{/if}}
+
         <span class="reply-count">
           {{icon "reply"}}
           {{@outletArgs.topic.replyCount}}

--- a/javascripts/discourse/services/recent-topics.js
+++ b/javascripts/discourse/services/recent-topics.js
@@ -1,0 +1,179 @@
+import { tracked } from "@glimmer/tracking";
+import Service, { service } from "@ember/service";
+
+const STORAGE_KEY = "deddit_recent_topics";
+const TOPIC_COUNT = 3;
+
+const CACHE_DURATION = 5 * 60 * 1000;
+
+const MAX_RESTORE_AGE = 24 * 60 * 60 * 1000;
+
+const PERSISTED_FIELDS = [
+  "id",
+  "title",
+  "fancy_title",
+  "slug",
+  "created_at",
+  "posts_count",
+  "category_id",
+  "pinned",
+  "closed",
+  "tags",
+  "last_read_post_number",
+  "like_count",
+];
+
+function serializeTopic(topic) {
+  const attrs = {};
+
+  for (const field of PERSISTED_FIELDS) {
+    attrs[field] = topic[field];
+  }
+
+  attrs.posters = (topic.posters ?? []).map((poster) => ({
+    user: { username: poster.user?.username },
+  }));
+
+  attrs.thumbnails = (topic.thumbnails ?? []).map((thumbnail) => ({
+    url: thumbnail.url,
+    width: thumbnail.width,
+    height: thumbnail.height,
+  }));
+
+  return attrs;
+}
+
+export default class RecentTopics extends Service {
+  @service store;
+  @service currentUser;
+  @service keyValueStore;
+
+  @tracked topics = null;
+  @tracked usingFallback = false;
+
+  cachedAt = 0;
+  pendingRequest = null;
+
+  constructor() {
+    super(...arguments);
+    this.restore();
+  }
+
+  get isStale() {
+    return !this.topics || Date.now() - this.cachedAt > CACHE_DURATION;
+  }
+
+  // only true once we've actually loaded and found nothing — while topics is
+  // still null the sidebar should show its placeholders
+  get isEmpty() {
+    return this.topics?.length === 0;
+  }
+
+  async load() {
+    if (!this.isStale) {
+      return;
+    }
+
+    this.pendingRequest ??= this.fetch();
+
+    try {
+      await this.pendingRequest;
+    } catch {
+      // nothing here is worth surfacing an error for, but leaving topics null
+      // would shimmer forever — hide the section until the next page load
+      this.topics ??= [];
+    } finally {
+      this.pendingRequest = null;
+    }
+  }
+
+  recordVisit(topic) {
+    if (!this.currentUser || !topic || topic.closed) {
+      return;
+    }
+
+    // TopicViewSerializer has no posters, so a topic opened by direct URL has
+    // nothing to render a byline from. Leave those to the next refresh rather
+    // than showing a blank "@"
+    if (!topic.posters?.length) {
+      return;
+    }
+
+    const others = this.usingFallback
+      ? []
+      : (this.topics ?? []).filter((t) => t.id !== topic.id);
+
+    this.usingFallback = false;
+    this.topics = [topic, ...others].slice(0, TOPIC_COUNT);
+    this.persist();
+  }
+
+  async fetch() {
+    let topics = await this.fetchList(
+      this.currentUser
+        ? { filter: "read", params: { order: "latest" } }
+        : { filter: "latest", params: { order: "created" } }
+    );
+
+    this.usingFallback = topics.length === 0;
+
+    if (this.usingFallback) {
+      topics = await this.fetchList({ filter: "hot" });
+    }
+
+    this.topics = topics;
+    this.cachedAt = Date.now();
+    this.persist();
+  }
+
+  async fetchList(args) {
+    const topicList = await this.store.findFiltered("topicList", args);
+
+    return topicList.topics
+      .filter((topic) => !topic.closed)
+      .slice(0, TOPIC_COUNT);
+  }
+
+  persist() {
+    try {
+      this.keyValueStore.setObject({
+        key: STORAGE_KEY,
+        value: {
+          userId: this.currentUser?.id ?? null,
+          cachedAt: this.cachedAt,
+          usingFallback: this.usingFallback,
+          topics: this.topics.map(serializeTopic),
+        },
+      });
+    } catch {
+      this.keyValueStore.remove(STORAGE_KEY);
+    }
+  }
+
+  restore() {
+    const cached = this.keyValueStore.getObject(STORAGE_KEY);
+
+    if (!cached || !cached.topics?.length) {
+      return;
+    }
+
+    if (cached.userId !== (this.currentUser?.id ?? null)) {
+      return;
+    }
+
+    if (Date.now() - cached.cachedAt > MAX_RESTORE_AGE) {
+      return;
+    }
+
+    try {
+      this.topics = cached.topics.map((attrs) =>
+        this.store.createRecord("topic", attrs)
+      );
+      this.usingFallback = cached.usingFallback ?? false;
+      this.cachedAt = cached.cachedAt;
+    } catch {
+      this.topics = null;
+      this.keyValueStore.remove(STORAGE_KEY);
+    }
+  }
+}

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -11,6 +11,7 @@ en:
   about_tag_admin_tip_description: "You can add a tag description here by"
   about_tag_admin_tip_description_link: "clicking this link."
   recent_topics: "Recent topics"
+  hot_topics: "Hot topics"
   top_tags: "Top tags"
   subcategories: "Subcategories"
   posted_by: "Posted by"

--- a/scss/composer.scss
+++ b/scss/composer.scss
@@ -31,12 +31,13 @@
 
   .grippie {
     background: none;
-    margin-top: -1em;
+    margin-top: -1.35em;
     display: inline-block;
+    padding: 1em 0;
 
     &::before {
       margin-left: calc(50% - 2.25em);
-      padding: 0.75em 1em;
+      padding: 0.25em 1em;
       margin-right: calc(50% - 1.85em);
       border-top-color: var(--redditish-border-color);
     }
@@ -93,6 +94,14 @@
       }
     }
   }
+}
+
+.composer-action-title {
+  font-size: var(--font-down-1);
+}
+
+.composer-toggle-switch {
+  margin-left: 0;
 }
 
 .d-editor-button-bar {

--- a/scss/right-sidebar.scss
+++ b/scss/right-sidebar.scss
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   gap: 1em;
-  margin-top: 1.5em;
+  margin-top: 1em;
   grid-area: sidebar2;
   top: calc(var(--header-offset) + 1em);
   align-self: start;
@@ -152,6 +152,33 @@
 
       .link-top-line {
         font-size: var(--font-0);
+      }
+    }
+
+    &-topics-placeholder {
+      display: flex;
+      flex-direction: column;
+      gap: 0.45em;
+      padding: 1em 0;
+
+      .placeholder-line {
+        height: 0.7em;
+        border-radius: 0.25em;
+
+        // core only gives .placeholder-animation a background inside a
+        // prefers-reduced-motion: no-preference query, so these would be
+        // invisible otherwise. Scoped to reduce so it can't beat the gradient
+        @media (prefers-reduced-motion: reduce) {
+          background: var(--primary-low);
+        }
+
+        &.--title {
+          height: 0.9em;
+        }
+
+        &.--short {
+          width: 60%;
+        }
       }
     }
 

--- a/scss/topic-list.scss
+++ b/scss/topic-list.scss
@@ -17,6 +17,10 @@ body.category,
   }
 }
 
+.d-combo-button.topic-create-button__combo {
+  display: none;
+}
+
 .topic-above-suggested-outlet,
 .related-messages-wrapper,
 .suggested-topics-wrapper {

--- a/settings.yml
+++ b/settings.yml
@@ -1,3 +1,7 @@
 hide_topic_footer_controls:
   default: true
   description: "Hides the reply/bookmark/share buttons at the bottom of each topic"
+
+show_like_count:
+  default: false
+  description: "Shows the like count before the reply count in the topic list"

--- a/spec/system/custom_post_bar_spec.rb
+++ b/spec/system/custom_post_bar_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+RSpec.describe "Creating a topic from the custom post bar", system: true do
+  let!(:theme) { upload_theme }
+  let(:composer) { PageObjects::Components::Composer.new }
+
+  # without refreshing auto groups the user isn't in trust_level_0, so
+  # can_create_topic? is false and the post bar renders nothing
+  fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
+
+  before { sign_in(user) }
+
+  it "opens the composer when the fake input is clicked" do
+    visit("/latest")
+
+    find(".custom-post-bar-contents input").click
+
+    expect(composer).to be_opened
+  end
+end

--- a/test/acceptance/redditish-recent-topics-test.js
+++ b/test/acceptance/redditish-recent-topics-test.js
@@ -1,0 +1,72 @@
+import { visit } from "@ember/test-helpers";
+import { test } from "qunit";
+import { cloneJSON } from "discourse/lib/object";
+import discoveryFixture from "discourse/tests/fixtures/discovery-fixtures";
+import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+
+function topicListResponse() {
+  return cloneJSON(discoveryFixture["/latest.json"]);
+}
+
+let readRequests;
+let readResponse;
+
+acceptance("Redditish Theme | recent topics sidebar", function (needs) {
+  // "top" is deliberately left out so it can be used as a non-top route, which
+  // is what unmounts the sidebar
+  needs.settings({ top_menu: "latest|new|unread|categories" });
+  needs.user({ sidebar_tags: [], sidebar_category_ids: [] });
+
+  needs.pretender((server, helper) => {
+    readRequests = 0;
+    readResponse = topicListResponse();
+
+    server.get("/read.json", () => {
+      readRequests++;
+      return helper.response(readResponse);
+    });
+
+    server.get("/hot.json", () => helper.response(topicListResponse()));
+    server.get("/top.json", () => helper.response(topicListResponse()));
+  });
+
+  test("renders the read list", async function (assert) {
+    await visit("/latest");
+
+    assert.dom(".custom-right-sidebar_recent h4").hasText("Recent topics");
+    assert
+      .dom(".custom-right-sidebar_recent-topics-wrapper")
+      .exists({ count: 3 });
+
+    // the byline is stitched together from topic_list.users by core's
+    // TopicList.munge, so this breaks if the poster payload changes shape
+    assert
+      .dom(
+        ".custom-right-sidebar_recent-topics-wrapper:first-child .custom-topic-layout_meta-posted a"
+      )
+      .hasText("@sam");
+  });
+
+  test("falls back to hot topics when there is no read history", async function (assert) {
+    readResponse = topicListResponse();
+    readResponse.topic_list.topics = [];
+
+    await visit("/latest");
+
+    assert.dom(".custom-right-sidebar_recent h4").hasText("Hot topics");
+    assert
+      .dom(".custom-right-sidebar_recent-topics-wrapper")
+      .exists({ count: 3 });
+  });
+
+  test("serves the list from cache after remounting", async function (assert) {
+    await visit("/latest");
+    await visit("/top"); // not in top_menu, so the sidebar unmounts
+    await visit("/latest");
+
+    assert
+      .dom(".custom-right-sidebar_recent-topics-wrapper")
+      .exists({ count: 3 });
+    assert.strictEqual(readRequests, 1, "the list is served from cache");
+  });
+});

--- a/test/acceptance/redditish-recent-topics-test.js
+++ b/test/acceptance/redditish-recent-topics-test.js
@@ -44,7 +44,7 @@ acceptance("Redditish Theme | recent topics sidebar", function (needs) {
       .dom(
         ".custom-right-sidebar_recent-topics-wrapper:first-child .custom-topic-layout_meta-posted a"
       )
-      .hasText("@sam");
+      .hasText("@reyman64");
   });
 
   test("falls back to hot topics when there is no read history", async function (assert) {

--- a/test/acceptance/redditish-topic-list-item-test.js
+++ b/test/acceptance/redditish-topic-list-item-test.js
@@ -38,7 +38,7 @@ acceptance("Redditish Theme | custom topic list item", function (needs) {
     // pins the poster payload the outlet hands us
     assert
       .dom(".topic-list-item .custom-topic-layout_meta-posted a")
-      .hasText("@sam");
+      .hasText("@reyman64");
   });
 
   test("opens the topic when the row is clicked", async function (assert) {

--- a/test/acceptance/redditish-topic-list-item-test.js
+++ b/test/acceptance/redditish-topic-list-item-test.js
@@ -1,0 +1,54 @@
+import { click, currentURL, visit } from "@ember/test-helpers";
+import { test } from "qunit";
+import { cloneJSON } from "discourse/lib/object";
+import discoveryFixture from "discourse/tests/fixtures/discovery-fixtures";
+import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+
+acceptance("Redditish Theme | custom topic list item", function (needs) {
+  needs.user({ sidebar_tags: [], sidebar_category_ids: [] });
+
+  needs.pretender((server, helper) => {
+    server.get("/latest.json", () => {
+      const response = cloneJSON(discoveryFixture["/latest.json"]);
+
+      // point the first row at a topic the default pretender can serve, so
+      // clicking it can actually navigate
+      const topic = response.topic_list.topics[0];
+      topic.id = 280;
+      topic.slug = "internationalization-localization";
+      topic.title = "Internationalization / localization";
+      topic.fancy_title = "Internationalization / localization";
+
+      return helper.response(response);
+    });
+
+    // the recent topics sidebar fetches this on top routes
+    server.get("/read.json", () =>
+      helper.response(cloneJSON(discoveryFixture["/latest.json"]))
+    );
+  });
+
+  test("renders the custom layout", async function (assert) {
+    await visit("/latest");
+
+    assert
+      .dom(".topic-list-item .raw-topic-link")
+      .hasText("Internationalization / localization");
+
+    // pins the poster payload the outlet hands us
+    assert
+      .dom(".topic-list-item .custom-topic-layout_meta-posted a")
+      .hasText("@sam");
+  });
+
+  test("opens the topic when the row is clicked", async function (assert) {
+    await visit("/latest");
+
+    await click(".topic-list-item .custom-topic-layout");
+
+    assert.true(
+      currentURL().startsWith("/t/internationalization-localization/280"),
+      "navigates into the topic"
+    );
+  });
+});


### PR DESCRIPTION
Adds a new theme setting, default false, `show_like_count` which will render the like count on the custom topic list items 

Adds cache and improves rendering on the recent topics sidebar. The list is now cached in localStorage and renders immediately, with a loading skeleton only on first load. If there's no read history it falls back to hot topics, and hides entirely if both are empty. For signed-in users, visiting a topic prepends it to the list so the cache stays accurate between refreshes. 